### PR TITLE
Docs: Add Usage Guide for manual verification and monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,30 @@ This flow can be used if batch processing background flow is desired in cases yo
 
 *See full blog for detailed considerations*
 
+## Usage Guide
+
+### 1. Verification (Manual Trigger)
+To manually trigger a new analysis and view results:
+
+```bash
+# 1. Start Analysis Pipeline
+export SM_ARN=$(aws stepfunctions list-state-machines --query "stateMachines[?contains(name, 'pod-metadata')].stateMachineArn" --output text)
+aws stepfunctions start-execution --state-machine-arn $SM_ARN
+
+# 2. Wait ~1-2 minutes for execution to complete
+
+# 3. Query Results
+export RESULT_LOC="s3://$(aws s3 ls | grep athena-results | awk '{print $3}')/"
+aws athena start-query-execution \
+    --query-string 'SELECT * FROM "eks-inter-az-visibility"."athena-results-table" ORDER BY "timestamp" DESC, "bytes_transfered";' \
+    --result-configuration OutputLocation=$RESULT_LOC
+```
+
+### 2. Automated Monitoring
+- The system automatically runs **every hour** via EventBridge.
+- You can view the data anytime by running the Athena query above.
+
+
 ## Cleanup
 
 ### Destroy the CDK Stack


### PR DESCRIPTION
*Issue #, if available:* N/A
*Description of changes:*
Added a **Usage Guide** section to the [README.md](cci:7://file:///home/abhay/Tasks/Kubekeeper/eks-inter-az-traffic-visibility/amazon-eks-inter-az-traffic-visibility/README.md:0:0-0:0) to improve the developer experience. This guide helps users:
1. **Manually trigger** the analysis pipeline using AWS Step Functions (essential for immediate verification/testing).
2. **Query results** in Amazon Athena with a copy-pasteable SQL snippet.
3. Understand the **automated hourly monitoring** schedule (EventBridge).
4. Perform **cleanup** to avoid incurring costs.
This addition allows users to verify their deployment and view cross-AZ traffic data immediately, without needing to decipher the Step Functions or Athena console setup manually.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.